### PR TITLE
Add file extensions

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,8 @@
       "file-types": [
         "vert",
         "frag",
+        "vsh",
+        "fsh",
         "glsl"
       ]
     }


### PR DESCRIPTION
Added the .vsh extension for vertex shader properties and the .fsh extension for fragment shader properties. These are also popular file extensions for the OpenGL Shader Language and it happens that this extension is lacking it.

Only package.json is edited.

Not tested as I'm unable to build it.