### PR TITLE
Add fix to grammer for type casting

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -5,10 +5,12 @@ module.exports = grammar(C, {
 
     conflicts: ($, original) => original.concat([
         [$.function_definition, $.declaration],
-        [$.declaration]
+        [$.declaration],
+        [$.cast_expression],
     ]),
 
     rules: {
+
         _top_level_item: ($, original) => choice(
             ...original.members.filter((member) => member.content?.name != '_old_style_function_definition'),
             $.preproc_extension,
@@ -30,6 +32,15 @@ module.exports = grammar(C, {
             )
             , original
         ),
+
+        cast_expression: $ => prec(C.PREC.CAST, seq(
+          field('type', choice(
+            $.primitive_type
+          )),
+          '(',
+          field('value', $.expression),
+          ')',
+        )),
 
         preproc_extension: $ => seq(
           field('directive', $.preproc_directive),


### PR DESCRIPTION
Fix GLSL type casting parsing by changing the cast_expression sequence

GLSL uses function-style type constructors like float(x), int(x), etc. These were incorrectly parsed as cast_expression sequence is inherited from C grammar, and C use casting like (int) x and casting using function style is in-valid in C and in GLSL later is the correct way to cast variables. And since this was not accounted for, it was causing parsing errors when used inside parentheses.

This change restricts cast_expression to follow the function-style constructor casting sequence.

Fixes parsing of expressions like: (float(x) * 1.5)